### PR TITLE
change to setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -3,15 +3,14 @@
 
 # Check which python version is installed
 function check_installed_python() {
-    which python3.7
-    if [ $? -eq 0 ]; then
+    python_v=$(pythonversion=$(python -V 2>&1 | grep -Po '(?<=Python )(.+)') && echo "python"$pythonversion | cut -c1-9)
+    if [ $python_v == "python3.7" ]; then
         echo "using Python 3.7"
         PYTHON=python3.7
         return
     fi
 
-    which python3.6
-    if [ $? -eq 0 ]; then
+    if [ $python_v == "python3.6" ]; then
         echo "using Python 3.6"
         PYTHON=python3.6
         return
@@ -274,6 +273,9 @@ reset
 ;;
 --plot|-p)
 plot
+;;
+--check-installed-python|-t)
+check_installed_python
 ;;
 *)
 help


### PR DESCRIPTION
If you are using a virtualenv with python3.6, then running the setup.sh script will still return python3.7 = True from executing "which python3.7" then installs python3.7 , if the script makes it to "which python3.6" it will return True also

You want to use the python version that is installed in your virtualenv, 3.6 being the case here

"which python3" will return python3 which isn't helpful either
I've added this method to get the current version of python3 being used by the environment
 python_v=$(pythonversion=$(python -V 2>&1 | grep -Po '(?<=Python )(.+)') && echo "python"$pythonversion | cut -c1-9)
changing the script in this was may eliminate some of the if then else logic but I've left it intact until can be tested further.

Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)

## Summary
Explain in one sentence the goal of this PR

Solve the issue: #___

## Quick changelog

- <change log #1>
- <change log #2>

## What's new?
*Explain in details what this PR solve or improve. You can include visuals.* 
